### PR TITLE
Reset arrow position when pressing escape

### DIFF
--- a/src/A11yCombobox.vue
+++ b/src/A11yCombobox.vue
@@ -119,6 +119,7 @@ export default {
       }
     },
     onEscape () {
+      this.arrowPosition = -1
       this.inputValue = ''
     },
     onResultClick (id) {

--- a/tests/unit/A11yCombobox.spec.js
+++ b/tests/unit/A11yCombobox.spec.js
@@ -177,5 +177,12 @@ describe('A11yCombobox.vue', () => {
 
       expect(wrapper.vm.inputValue).toBe('')
     })
+
+    it('resets the arrow position', () => {
+      wrapper.setData({ inputValue: 'test' })
+      wrapper.vm.onEscape()
+
+      expect(wrapper.vm.arrowPosition).toBe(-1)
+    })
   })
 })


### PR DESCRIPTION
Pressing escape clears the value of the input. Not resetting the `arrowPosition` leads to a bug with `aria-activedescendant`